### PR TITLE
Refactor: split js/common.js into language, SVG, and frame modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,9 @@
 <script src="libs/d3.v7.js"></script>
 <script src="libs/d3-simple-slider.js"></script>
 <script src="js/translations.js"></script>
-<script src="js/common.js"></script>
+<script src="js/common-lang.js"></script>
+<script src="js/common-svg.js"></script>
+<script src="js/common-frame.js"></script>
 <script src="js/data.js"></script>
 <script src="js/citta-model.js"></script>
 <script src="js/citta.js"></script>

--- a/js/citta.js
+++ b/js/citta.js
@@ -1,3 +1,6 @@
+const cittaPageApi = getCittaPageApi();
+const cittaSvg = cittaPageApi.svg;
+
 function createCittaState() {
     return {
         itemIndex: {},

--- a/js/common-frame.js
+++ b/js/common-frame.js
@@ -1,0 +1,45 @@
+const tabs = d3.selectAll('.tabs button');
+const svgs = d3.selectAll('.svg-sub-container');
+
+function showTab(tabIndex) {
+    tabs.classed('active', (d, i) => i === parseInt(tabIndex));
+    svgs.classed('active', (d, i) => i === parseInt(tabIndex));
+}
+
+function syncTabWithHash() {
+    const hash = window.location.hash.substring(1);
+    if (hash) {
+        showTab(hash);
+    }
+}
+
+tabs.on('click', function () {
+    const tabIndex = tabs.nodes().indexOf(this);
+    history.pushState(null, '', `#${tabIndex}`);
+    showTab(tabIndex);
+});
+
+window.addEventListener('hashchange', syncTabWithHash);
+
+const langs = d3.selectAll('.lang button');
+function setLang(langIndex) {
+    langs.classed('active', (d, i) => i === langIndex);
+    if (localStorage) {
+        localStorage.setItem('lang', getLangByIndex(langIndex).name);
+    }
+}
+
+function syncLanguageButtons() {
+    const lang = getLang();
+    langs.classed('active', (d, i) => i === lang.index);
+}
+
+langs.on('click', function () {
+    const langIndex = langs.nodes().indexOf(this);
+    const oldLang = getLang().name;
+    setLang(langIndex);
+    const newLang = getLang().name;
+    if (oldLang !== newLang) {
+        window.location.reload();
+    }
+});

--- a/js/common-lang.js
+++ b/js/common-lang.js
@@ -1,0 +1,48 @@
+const langCfg = {
+    'en': {
+        name: 'en',
+        fixed: false,
+        px: 10,
+        vertical: false,
+        wrap: true,
+        wide: false,
+        index: 0
+    },
+    'cn': {
+        name: 'cn',
+        px: 14,
+        fixed: true,
+        vertical: true,
+        wrap: false,
+        wide: true,
+        index: 1
+    }
+};
+
+function getLangByIndex(index) {
+    for (let key in langCfg) {
+        if (langCfg[key].index === index) {
+            return langCfg[key];
+        }
+    }
+    return langCfg['cn'];
+}
+
+function getLang() {
+    if (localStorage) {
+        const lang = localStorage.getItem('lang');
+        if (langCfg[lang]) {
+            return langCfg[lang];
+        }
+        localStorage.setItem('lang', 'cn');
+    }
+    return langCfg['cn'];
+}
+
+function t(id) {
+    const lang = getLang();
+    if (!id || !tr[id]) {
+        return '';
+    }
+    return tr[id][lang.name] || tr[id]['cn'];
+}

--- a/js/common-svg.js
+++ b/js/common-svg.js
@@ -1,0 +1,358 @@
+const container = d3.select('.svg-container');
+const svgWidth = 1800;
+const svgHeight = 1000;
+const cittaSvg = container.select('#citta');
+const msSvg = container.select('#container2').append('svg').attr('class', 'svg-content').attr('width', svgWidth).attr('height', 1);
+const mmSvg = container.select('#container3').append('svg').attr('class', 'svg-content').attr('width', svgWidth).attr('height', 1);
+const rpSvg = container.select('#container4').append('svg').attr('class', 'svg-content').attr('width', svgWidth).attr('height', 1200);
+const rpgSvg = container.select('#container5').append('svg').attr('class', 'svg-content').attr('width', svgWidth).attr('height', svgHeight);
+const rpnSvg = container.select('#simulation');
+const rpnlSvg = container.select('#simulation-notes');
+const doSvg = container.select('#dependent-origination');
+const rpnsSvg = container.select('#container9').append('svg').attr('class', 'svg-content').attr('width', svgWidth).attr('height', 1);
+const testSvg = d3.select('#test-svg');
+const testDiv = d3.select('#test-div');
+const cdSvg = container.select('#left-svg-side-container').append('svg').attr('class', 'svg-content').attr('width', 380).attr('height', svgHeight * 2);
+const ceSvg = container.select('#right-svg-side-container').append('svg').attr('class', 'svg-content').attr('width', 1280).attr('height', svgHeight);
+const ccSvg = container.select('#cause-condition-svg');
+const mwSvg = container.select('#my-words-svg');
+
+function getCittaPageApi() {
+    return { svg: cittaSvg };
+}
+
+function renderCell(parent, x, y, w, h, color) {
+    const cell = parent.append('rect')
+        .attr('x', x)
+        .attr('y', y)
+        .attr('width', w)
+        .attr('height', h)
+        .attr('stroke', 'grey')
+        .attr('stroke-width', 1)
+        .attr('fill', color);
+    cell.X = x;
+    cell.Y = y;
+    cell.endX = x + w;
+    cell.endY = y + h;
+    return cell;
+}
+
+function renderCircle(parent, x, y, r, color) {
+    return parent.append('circle')
+        .attr('cx', x)
+        .attr('cy', y)
+        .attr('r', r)
+        .style('stroke', 'black')
+        .style('stroke-width', 1)
+        .attr('fill', color);
+}
+
+function updateParams(params={}) {
+    if (params.size === undefined) params.size = '16px';
+    if (params.padding === undefined) params.padding = 0;
+    if (params.align === undefined) params.align = 'middle';
+    if (params.valign === undefined) params.valign = 'middle';
+    if (params.vertical === undefined) params.vertical = false;
+    if (params.wrap === undefined) params.wrap = true;
+    return params;
+}
+
+function renderText(parent, x, y, w, h, text, params={}) {
+    if (!(text instanceof String)) {
+        text = text.toString();
+    }
+    params = updateParams(params);
+    const rx = (params.align === 'middle' ? x + w / 2 : x) + params.padding;
+    const ry = params.valign === 'top' ? y : y + h / 2;
+    const px = parseInt(params.size);
+    const textElement = parent.append('text')
+        .attr('x', rx)
+        .attr('y', ry)
+        .attr('text-anchor', params.align)
+        .attr('dominant-baseline', 'central')
+        .attr('font-size', params.size);
+
+    if (params.vertical) {
+        for (let i = 0; i < text.length; i++) {
+            textElement.append('tspan')
+                .attr('x', rx)
+                .attr('y', y + (i +1)* px)
+                .text(text[i]);
+        }
+    } else if (params.wrap) {
+        textElement.selectAll('tspan').remove();
+        const lang = getLang();
+        const aw = w - params.padding * 2;
+        if (lang.fixed) {
+            const len = Math.floor(aw / px);
+            const n = len === 0 ? 1 : Math.max(Math.ceil(text.length / len), 1);
+            if (n === 1) {
+                textElement.text(text);
+            } else {
+                for (let j = 0; j < n; ++j) {
+                    const part = text.substring(j * len, Math.min((j + 1) * len, text.length));
+                    textElement.append('tspan')
+                        .attr('x', rx)
+                        .attr('y', y + (j + 1) * px)
+                        .text(part);
+                }
+            }
+        } else {
+            const testTE = testSvg.append('text')
+                .attr('x', 0)
+                .attr('y', 0)
+                .attr('text-anchor', params.align)
+                .attr('dominant-baseline', 'central')
+                .attr('font-size', params.size);
+            testTE.text(text);
+            const len = testTE.node().getComputedTextLength();
+            if (len <= aw) {
+                textElement.text(text);
+            } else {
+                testTE.text('');
+                const words = text.split(' ');
+                let line = '';
+                let j = 0;
+                let k = 1;
+                for (let i = 0; i < words.length; i++) {
+                    const maybeLine = line + (line === '' ? '' : ' ') + words[i];
+                    const testTS = testTE.append('tspan')
+                        .text(maybeLine);
+                    const testLen = testTS.node().getComputedTextLength();
+                    testTS.remove();
+                    if (testLen > aw) {
+                        let cur = line;
+                        let next = words[i];
+                        if (i === 0) {
+                            cur = maybeLine.substring(0, Math.floor(maybeLine.length *0.7)) + '-';
+                            next = '-' + maybeLine.substring(Math.floor(maybeLine.length * 0.7));
+                        }
+                        textElement.append('tspan')
+                            .attr('x', rx)
+                            .attr('y', y + (j + 1) * px)
+                            .text(cur);
+                        line = next;
+                        k = 1;
+                        j++;
+                        const testTS = testTE.append('tspan')
+                            .text(line);
+                        const testLen = testTS.node().getComputedTextLength();
+                        testTS.remove();
+                        if (testLen > aw) {
+                            cur = line.substring(0, Math.floor(line.length *0.7)) + '-';
+                            next = '-' + line.substring(Math.floor(line.length * 0.7));
+                            textElement.append('tspan')
+                                .attr('x', rx)
+                                .attr('y', y + (j + 1) * px)
+                                .text(cur);
+                            line = next;
+                            k = 1;
+                            j++;
+                        }
+                    } else {
+                        line += (line === '' ? '' : ' ') + words[i];
+                        k++;
+                    }
+                    if (i === words.length - 1) {
+                        const ly = y + (j + 1) * px;
+                        textElement.append('tspan')
+                            .attr('x', rx)
+                            .attr('y', ly)
+                            .text(line);
+                    }
+                }
+            }
+            testTE.remove();
+        }
+    } else {
+        textElement.text(text);
+    }
+    return textElement;
+}
+
+function renderTextBox(parent, x, y, w, h, bgColor, text, params = {}) {
+    params = updateParams(params);
+    let item = parent.append('g');
+    let cell = renderCell(item, x, y, w, h, bgColor);
+    let textElement = renderText(item, x, y, w, h, text, params);
+    let markIdx = 0;
+    item.setText = function(newText) {
+        item.select('text').remove();
+        textElement = renderText(item, x, y, w, h, newText, params);
+    };
+    item.setColor = function(newColor) {
+        cell.attr('fill', newColor);
+    };
+    item.highlight = function () {
+        if (bgColor === 'white') {
+            cell.attr('fill', 'yellow');
+        } else {
+            cell.attr('fill', d3.color(bgColor).darker(0.5));
+        }
+    }
+    item.clear = function () {
+        cell.attr('fill', bgColor);
+    }
+    item.clearMarks = function () {
+        item.selectAll('circle').remove();
+        markIdx = 0;
+    }
+    item.mark = function (color) {
+        const r = h / 2 - 2;
+        markIdx++;
+        renderCircle(item, x + w - r * markIdx -2, y + h/2, r, color);
+    }
+    item.X = x;
+    item.Y = y;
+    item.endX = x + w;
+    item.endY = y + h;
+    return item;
+}
+
+function renderTextCircle(parent, x, y, r, bgColor, text, params = {}) {
+    params = updateParams(params);
+    let item = parent.append('g');
+    let cell = renderCircle(item, x, y, r, bgColor);
+    let textElement = renderText(item, x - r/1.414, y - r/1.414, r * 1.414, r * 1.414, text, params);
+    item.setText = function(newText) {
+        item.select('text').remove();
+        textElement = renderText(item, x - r/1.414, y - r/1.414, r * 1.414, r * 1.414, newText, params);
+    };
+    item.setColor = function(newColor) {
+        cell.attr('fill', newColor);
+    };
+    item.highlight = function () {
+        if (bgColor === 'white') {
+            cell.attr('fill', 'yellow');
+        } else {
+            cell.attr('fill', d3.color(bgColor).darker(0.5));
+        }
+    }
+    item.clear = function () {
+        cell.attr('fill', bgColor);
+    }
+    return item;
+}
+
+function setupArrowHead(svg, markerName) {
+    svg.append('defs')
+        .append('marker')
+        .attr('id', markerName)
+        .attr('viewBox', '0 0 10 10')
+        .attr('refX', 8)  // Adjust this to control the arrowhead positioning
+        .attr('refY', 5)
+        .attr('markerWidth', 6)
+        .attr('markerHeight', 6)
+        .attr('orient', 'auto')
+        .append('path')
+        .attr('d', 'M 0 0 L 10 5 L 0 10 Z') // Arrow shape
+        .attr('fill', 'black');
+}
+
+function connect(svg, x1, y1, x2, y2, markerName) {
+    return svg.append('path')
+        .attr('d', `M ${x1} ${y1} L ${x2} ${y2}`)
+        .attr('stroke', 'black')
+        .attr('stroke-width', 1)
+        .attr('marker-end', `url(#${markerName})`);
+}
+
+function line(svg, x1, y1, x2, y2) {
+    return svg.append('line')
+        .attr('x1', x1)
+        .attr('y1', y1)
+        .attr('x2', x2)
+        .attr('y2', y2)
+        .attr('stroke', 'black')
+        .attr('stroke-width', 1);
+}
+
+function subArraySum(array, start, end) {
+    let result = 0;
+    for (let i = start; i < end; ++i) {
+        result += array[i];
+    }
+    return result;
+}
+
+function getWordLength(text, px) {
+    const lang = getLang();
+    if (lang.fixed) {
+        let count = 0;
+        for (let char of text) {
+            if (/[\x00-\x7F]/.test(char)) {
+                count++;
+            } else {
+                count += 2;
+            }
+        }
+        return count * px / 2 + 3;
+    }
+    const testTE = testSvg.append('text')
+        .attr('x', 0)
+        .attr('y', 0)
+        .attr('font-size', px)
+        .text(text);
+    const len = testTE.node().getComputedTextLength();
+    testTE.remove();
+    return len;
+}
+
+function renderVerticalTable(parent, x, y, w, h, title, items, padding, itemIndex, compact, headerColor) {
+    // Define the table's header and item height
+    const headerHeight = compact ? 12 : 20;
+    const headerFontSize = compact ? '10px' : '12px';
+    const rowHeight = compact ? 12 : 15;
+    if (!padding) {
+        padding = 0;
+    }
+
+    // Create a group for the table
+    const tableGroup = parent.append('g')
+        .attr('transform', `translate(${x}, ${y})`);
+
+    // Draw the header row
+    renderTextBox(tableGroup, padding, padding, w - padding * 2, headerHeight, headerColor ? headerColor : 'lightgrey', title, {size: headerFontSize, padding: 2, align: 'left'});
+    const boxes = [];
+    // Loop through the data items and draw each row
+    items.forEach((item, index) => {
+        const yPosition = padding + headerHeight + index * rowHeight;
+        const textbox = renderTextBox(tableGroup, padding, yPosition, w - padding * 2, rowHeight, 'white', item.name, {
+            size: '10px',
+            padding: 2,
+            align: 'left'
+        });
+        if (itemIndex) {
+            textbox.X += x;
+            textbox.Y += y;
+            textbox.endX += x;
+            textbox.endY += y;
+            itemIndex[item.id] = textbox;
+        }
+        boxes.push(textbox);
+    });
+    tableGroup.setColor = function (color) {
+        boxes.forEach((box, i) => {
+            box.setColor(color);
+        })
+    }
+    tableGroup.endX = x + w - padding;
+    tableGroup.endY = y + padding + headerHeight + items.length * rowHeight + padding;
+    return tableGroup;
+}
+
+function createElbowConnector(parent, x1, y1, x2, y2, len, color) {
+    const midX = len ? x1 + len : (x1 + x2) / 2;
+    const pathData = `M ${x1} ${y1} H ${midX} V ${y2} H ${x2}`;
+
+    parent.append('path')
+        .attr('d', pathData)
+        .attr('stroke', color ? color : 'black')
+        .attr('stroke-width', 1)
+        .attr('fill', 'none')
+        .attr('class', 'elbow-connector');
+}
+
+function removeAllConnectors(parent) {
+    parent.selectAll('path.elbow-connector').remove();
+}

--- a/js/main.js
+++ b/js/main.js
@@ -71,12 +71,9 @@ function render() {
 
     renderCauseCondition(ccSvg);
     renderMyWords(mwSvg);
-    const hash = window.location.hash.substring(1); // Get the hash without the '#'
-    if (hash) {
-        showTab(hash);
-    }
+    syncTabWithHash();
 
-    langs.classed('active', (d, i) => i === lang.index);
+    syncLanguageButtons();
     testDiv.style('display', 'none;');
 }
 


### PR DESCRIPTION
### Motivation
- Reduce `js/common.js` monolith by separating concerns for language/translation, SVG rendering primitives, and page-frame interactions to prepare for migrating the citta/cetasika modules.
- Expose a minimal page-specific API for the citta page to avoid direct global DOM reads inside that module while keeping existing behavior unchanged.

### Description
- Introduced `js/common-lang.js` containing `langCfg`, `getLangByIndex`, `getLang`, and `t` for language configuration and translation lookup.
- Introduced `js/common-svg.js` containing SVG container setup and rendering primitives such as `renderCell`, `renderText`, `renderCircle`, `renderTextBox`, `renderTextCircle`, connector helpers, and `getCittaPageApi()` which returns `{ svg: cittaSvg }`.
- Introduced `js/common-frame.js` containing frame-level interactions: tab switching, `showTab`, `syncTabWithHash`, `hashchange` listener, language button behavior and `syncLanguageButtons`/`setLang` helpers.
- Updated `index.html` to load `js/common-lang.js`, `js/common-svg.js`, and `js/common-frame.js` instead of the old `js/common.js`.
- Updated `js/main.js` to call `syncTabWithHash()` and `syncLanguageButtons()` instead of directly manipulating tab/language DOM state at render end.
- Updated `js/citta.js` to consume the minimal page API via `const cittaPageApi = getCittaPageApi(); const cittaSvg = cittaPageApi.svg;` to avoid direct global selector usage.

### Testing
- Ran a JS sanity check by loading the new modules with `node -e "const fs=require('fs');['js/common-lang.js','js/common-svg.js','js/common-frame.js','js/main.js','js/citta.js'].forEach(f=>new Function(fs.readFileSync(f,'utf8'))); console.log('ok')"` and it completed successfully.
- An earlier automated check attempted to parse `index.html` as JS and failed; that was due to passing an HTML file to the JS loader and was resolved before committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe29d7898083278467dd4ae0757810)