### PR TITLE
Introduce page state and view-model layers; unify CN/EN rendering and parameterize layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,9 @@
 <script src="js/common-lang.js"></script>
 <script src="js/common-svg.js"></script>
 <script src="js/common-frame.js"></script>
+<script src="js/page-state.js"></script>
+<script src="js/view-model.js"></script>
+<script src="js/render-layout.js"></script>
 <script src="js/data.js"></script>
 <script src="js/citta-model.js"></script>
 <script src="js/citta.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -10,40 +10,40 @@ function clearAll() {
     rpnlSvg.selectAll('*').remove();
 }
 
+const pageState = createPageState();
+
 function render() {
-    const lang = getLang();
+    refreshPageState(pageState);
+    const viewModel = buildPageViewModel(pageState);
+    const lang = viewModel.lang;
 
     const subPadding = 6;
     const ctt = renderCittaTable(cittaSvg);
     let cntt = null;
     let ntt = null;
-    if (lang.fixed) {
-        const rx = ctt.endX + subPadding;
-        const fet = renderFeelingTable(rx, 0);
-        const ct = renderCauseTable(fet.endX + subPadding, 0);
-        const tt = renderTimeTable(rx, subPadding + ct.endY);
-        const fot = renderFiveObjectsTable(tt.endX + subPadding, subPadding + ct.endY);
-        const mot = renderMentalObjectsTable(rx, tt.endY + subPadding);
-        const rt = renderRealmTable(rx, mot.endY + subPadding);
-        const gt = renderGateTable(rt.endX + subPadding, mot.endY + subPadding);
-        const bt = renderBasisTable(rx, gt.endY + subPadding);
-        const ft = renderFunctionTable(rx, bt.endY + subPadding);
+    const sidePanelLayout = viewModel.layout.cittaSidePanel;
+    const rx = ctt.endX + subPadding;
+    const fet = renderFeelingTable(rx, 0);
+    const ct = renderCauseTable(fet.endX + subPadding, 0);
+    const tt = sidePanelLayout.stacked
+        ? renderTimeTable(rx, subPadding + ct.endY)
+        : renderTimeTable(ct.endX + subPadding, 0);
+    const fot = renderFiveObjectsTable(tt.endX + subPadding, sidePanelLayout.stacked ? subPadding + ct.endY : 0);
+    const mot = renderMentalObjectsTable(rx, sidePanelLayout.stacked ? tt.endY + subPadding : ct.endY + subPadding);
+    const rt = renderRealmTable(sidePanelLayout.stacked ? rx : mot.endX + subPadding, sidePanelLayout.stacked ? mot.endY + subPadding : ct.endY + subPadding);
+    const gt = renderGateTable(rt.endX + subPadding, sidePanelLayout.stacked ? mot.endY + subPadding : ct.endY + subPadding);
+    const bt = renderBasisTable(sidePanelLayout.stacked ? rx : gt.endX + subPadding, gt.endY + subPadding);
+    const ft = renderFunctionTable(rx, bt.endY + subPadding);
+    if (sidePanelLayout.stacked) {
         cntt = renderCounterTable(rx, ft.endY + subPadding);
         ntt = renderNoteTable(rx, cntt.endY + subPadding);
     } else {
-        const rx = ctt.endX + subPadding;
-        const fet = renderFeelingTable(rx, 0);
-        const ct = renderCauseTable(fet.endX + subPadding, 0);
-        const tt = renderTimeTable(ct.endX + subPadding, 0);
-        const fot = renderFiveObjectsTable(tt.endX + subPadding, 0);
-        const mot = renderMentalObjectsTable(rx, ct.endY + subPadding);
-        const rt = renderRealmTable(mot.endX + subPadding, ct.endY + subPadding);
-        const gt = renderGateTable(rt.endX  + subPadding, ct.endY + subPadding);
-        const bt = renderBasisTable(gt.endX + subPadding, ct.endY + subPadding);
-        const ft = renderFunctionTable(rx, bt.endY + subPadding);
-        ntt = renderNoteTable(ft.endX + subPadding, bt.endY + subPadding, 80, 12);
-        cntt = renderCounterTable(ft.endX + subPadding, ntt.endY + subPadding, 80, 12);
+        ntt = renderNoteTable(ft.endX + subPadding, bt.endY + subPadding, sidePanelLayout.notesWidth, sidePanelLayout.notesFontSize);
+        cntt = renderCounterTable(ft.endX + subPadding, ntt.endY + subPadding, sidePanelLayout.notesWidth, sidePanelLayout.notesFontSize);
     }
+    pageState.citta.layout = ctt;
+    pageState.citta.counters = cntt;
+    pageState.citta.notes = ntt;
 
     renderCetasikaTable(ctt.endY + 15);
     setupHighlightsBehavior(cntt, ntt);
@@ -56,7 +56,7 @@ function render() {
     renderControls(mindFlowState, 1, 6);
 
     const rat = renderRupaAttrTable(rpSvg);
-    const offset = lang.wide ? 100 : 240;
+    const offset = viewModel.layout.rupaNotesOffset;
     renderNotesTable(rpSvg, rat.endX + offset, 0);
     renderRupaAggTable(rpSvg, 0, rat.endY + subPadding);
     setupRupaHighlightBehavior();

--- a/js/page-state.js
+++ b/js/page-state.js
@@ -1,0 +1,22 @@
+function createPageState() {
+    return {
+        lang: getLang(),
+        citta: {
+            layout: null,
+            counters: null,
+            notes: null,
+        },
+        flows: {
+            sense: senseFlowState,
+            mind: mindFlowState,
+        },
+        rupa: {
+            attrTable: null,
+        },
+    };
+}
+
+function refreshPageState(pageState) {
+    pageState.lang = getLang();
+    return pageState;
+}

--- a/js/render-layout.js
+++ b/js/render-layout.js
@@ -1,0 +1,18 @@
+const CITTA_SIDE_PANEL_LAYOUTS = {
+    cn: {
+        timeXBy: 'feeling',
+        notesWidth: 80,
+        notesFontSize: 12,
+        stacked: true,
+    },
+    en: {
+        timeXBy: 'cause',
+        notesWidth: 80,
+        notesFontSize: 12,
+        stacked: false,
+    },
+};
+
+function getCittaSidePanelLayout(lang) {
+    return lang.fixed ? CITTA_SIDE_PANEL_LAYOUTS.cn : CITTA_SIDE_PANEL_LAYOUTS.en;
+}

--- a/js/view-model.js
+++ b/js/view-model.js
@@ -1,0 +1,13 @@
+function buildPageViewModel(pageState) {
+    const lang = pageState.lang || getLang();
+    return {
+        lang,
+        citta: {
+            raw: { data, cittas, cetasika },
+        },
+        layout: {
+            cittaSidePanel: getCittaSidePanelLayout(lang),
+            rupaNotesOffset: lang.wide ? 100 : 240,
+        },
+    };
+}


### PR DESCRIPTION
### Motivation
- Centralize render-time state so the rendering orchestration no longer reaches arbitrarily into deep `data.js` structures. 
- Provide a small view-model conversion layer to decouple layout decisions from raw data and enable future transformation/mapping work. 
- Merge divergent CN/EN rendering branches into a single, parameterized flow so layout differences are driven by config rather than duplicated code.

### Description
- Added a page-level state container with `createPageState`/`refreshPageState` in `js/page-state.js` and instantiated it in `js/main.js`. 
- Introduced a view-model layer via `buildPageViewModel` in `js/view-model.js` to expose `lang`, `citta.raw`, and layout hints. 
- Extracted side-panel and language layout policy into `js/render-layout.js` and switched `js/main.js` to use `viewModel.layout.cittaSidePanel` and `viewModel.layout.rupaNotesOffset` to drive placement and sizing. 
- Wired the new modules into the load order in `index.html` and preserved the external `render()` entry while storing `ctt`, `cntt`, and `ntt` back into the `pageState.citta` for downstream use.

### Testing
- Verified file changes and new files with `git status --short` which listed added and modified files and completed without error. 
- Confirmed code diffs for the main orchestration with `git diff -- js/main.js` and inspected updated file contents via `nl -ba`/file listings to ensure the new flow is wired correctly. 
- No automated unit tests were present in the repo; the above verification commands completed successfully and showed the new files `js/page-state.js`, `js/view-model.js`, and `js/render-layout.js` were added and referenced by `index.html` and `js/main.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2d0a5660832781d3a021f408db70)