### PR TITLE
Refactor render into fault-isolated staged sections with per-stage logging and debug panel

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -12,11 +12,44 @@ function clearAll() {
 
 const pageState = createPageState();
 
-function render() {
-    refreshPageState(pageState);
-    const viewModel = buildPageViewModel(pageState);
-    const lang = viewModel.lang;
+function logRenderStage(stageName, marker, context = {}) {
+    const { tabId = 'unknown', lang = 'unknown', endX = '-', endY = '-' } = context;
+    console.log(`[render:${stageName}] ${marker}`, { tabId, lang, endX, endY });
+}
 
+function updateRenderDebugPanel(errors) {
+    if (!testDiv || testDiv.empty()) {
+        return;
+    }
+
+    if (!errors.length) {
+        testDiv.style('display', 'none').text('');
+        return;
+    }
+
+    const summary = errors
+        .map(({ stage, error }, index) => `${index + 1}. ${stage}: ${error && error.message ? error.message : String(error)}`)
+        .join('\n');
+
+    testDiv
+        .style('display', 'block')
+        .style('position', 'fixed')
+        .style('left', '8px')
+        .style('bottom', '8px')
+        .style('z-index', '9999')
+        .style('max-width', '40vw')
+        .style('max-height', '28vh')
+        .style('overflow', 'auto')
+        .style('padding', '8px 10px')
+        .style('background', 'rgba(180, 20, 20, 0.9)')
+        .style('color', '#fff')
+        .style('font-size', '12px')
+        .style('line-height', '1.4')
+        .style('white-space', 'pre-wrap')
+        .text(`Render errors:\n${summary}`);
+}
+
+function renderCittaSection(viewModel, context) {
     const subPadding = 6;
     const ctt = renderCittaTable(cittaSvg);
     let cntt = null;
@@ -28,7 +61,7 @@ function render() {
     const tt = sidePanelLayout.stacked
         ? renderTimeTable(rx, subPadding + ct.endY)
         : renderTimeTable(ct.endX + subPadding, 0);
-    const fot = renderFiveObjectsTable(tt.endX + subPadding, sidePanelLayout.stacked ? subPadding + ct.endY : 0);
+    renderFiveObjectsTable(tt.endX + subPadding, sidePanelLayout.stacked ? subPadding + ct.endY : 0);
     const mot = renderMentalObjectsTable(rx, sidePanelLayout.stacked ? tt.endY + subPadding : ct.endY + subPadding);
     const rt = renderRealmTable(sidePanelLayout.stacked ? rx : mot.endX + subPadding, sidePanelLayout.stacked ? mot.endY + subPadding : ct.endY + subPadding);
     const gt = renderGateTable(rt.endX + subPadding, sidePanelLayout.stacked ? mot.endY + subPadding : ct.endY + subPadding);
@@ -44,37 +77,76 @@ function render() {
     pageState.citta.layout = ctt;
     pageState.citta.counters = cntt;
     pageState.citta.notes = ntt;
-
     renderCetasikaTable(ctt.endY + 15);
     setupHighlightsBehavior(cntt, ntt);
 
+    context.endX = ctt.endX;
+    context.endY = Math.max(ntt ? ntt.endY : 0, cntt ? cntt.endY : 0);
+}
 
+function renderFlowSection(context) {
     renderFlow(senseFlowState);
     renderControls(senseFlowState, 1, 15);
-
     renderFlow(mindFlowState);
     renderControls(mindFlowState, 1, 6);
+    context.endX = 1;
+    context.endY = 15;
+}
 
+function renderRupaSection(viewModel, context) {
+    const subPadding = 6;
     const rat = renderRupaAttrTable(rpSvg);
     const offset = viewModel.layout.rupaNotesOffset;
     renderNotesTable(rpSvg, rat.endX + offset, 0);
     renderRupaAggTable(rpSvg, 0, rat.endY + subPadding);
     setupRupaHighlightBehavior();
     renderRupaOrigins(rpgSvg);
+    context.endX = rat.endX + offset;
+    context.endY = rat.endY + subPadding;
+}
 
+function renderConditionSection(context) {
     createLegend();
     createProgressUpdater();
-
     dependentOrigination(doSvg, dependentOriginData);
-
     renderConditionsMapping(cdSvg, ceSvg);
-
     renderCauseCondition(ccSvg);
     renderMyWords(mwSvg);
+    context.endX = '-';
+    context.endY = '-';
+}
+
+function executeRenderStage(stageName, context, errors, callback) {
+    logRenderStage(stageName, 'start', context);
+    try {
+        callback();
+        logRenderStage(stageName, 'done', context);
+    } catch (error) {
+        console.error(`[render:${stageName}] failed`, error);
+        errors.push({ stage: stageName, error });
+    }
+}
+
+function render() {
+    refreshPageState(pageState);
+    const viewModel = buildPageViewModel(pageState);
+    const context = {
+        tabId: pageState.tab && pageState.tab.id ? pageState.tab.id : 'unknown',
+        lang: viewModel.lang,
+        endX: '-',
+        endY: '-',
+    };
+    const renderErrors = [];
+
+    executeRenderStage('citta', context, renderErrors, () => renderCittaSection(viewModel, context));
+    executeRenderStage('flow', context, renderErrors, () => renderFlowSection(context));
+    executeRenderStage('rupa', context, renderErrors, () => renderRupaSection(viewModel, context));
+    executeRenderStage('condition', context, renderErrors, () => renderConditionSection(context));
+
     syncTabWithHash();
 
     syncLanguageButtons();
-    testDiv.style('display', 'none');
+    updateRenderDebugPanel(renderErrors);
 }
 
 // On page load, check the URL


### PR DESCRIPTION
### Motivation

- Make `render()` more resilient by breaking it into independent phases so a failure in one area doesn't block others.
- Improve observability to speed up diagnosing which rendering stage (citta/flow/rupa/condition) failed and with what context.

### Description

- Split the monolithic `render()` into stage functions `renderCittaSection`, `renderFlowSection`, `renderRupaSection`, and `renderConditionSection`, each computing/setting local layout results and `context` end coordinates.
- Added `executeRenderStage(stageName, context, errors, callback)` which wraps each stage in `try/catch` and collects errors without aborting subsequent stages.
- Added `logRenderStage(stageName, marker, context)` to emit start/done logs including `tabId`, `lang`, `endX`, and `endY`, and `updateRenderDebugPanel(errors)` to show a compact fixed on-page error summary using the existing `testDiv` element.
- Replaced the previous single-run flow in `render()` with staged execution, passing a shared `context` and calling `updateRenderDebugPanel` with any collected stage errors.

### Testing

- Ran `node --check js/main.js` to validate syntax and the file passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe3ecb910c832783d500e99c1efbb2)