### PR TITLE
refactor: 将 Tab1 布局集中配置并增加布局边界校验

### DIFF
--- a/js/citta.js
+++ b/js/citta.js
@@ -61,12 +61,12 @@ function assertCittaModelStructure(model, functionName = 'unknown') {
     }
 }
 
-function renderCittaTable(parent, model, state = cittaState) {
+function renderCittaTable(parent, model, state = cittaState, layoutConfig = {}) {
     assertCittaModelStructure(model, 'renderCittaTable');
-    const rowHeaderWidth = 120;
-    const columnWidths = [120, 120, 120, 220, 120, 120];
-    const columnHeaderHeight = 105;
-    const rowHeights = [210, 105, 90, 90];
+    const rowHeaderWidth = layoutConfig.rowHeaderWidth || 120;
+    const columnWidths = layoutConfig.columnWidths || [120, 120, 120, 220, 120, 120];
+    const columnHeaderHeight = layoutConfig.columnHeaderHeight || 105;
+    const rowHeights = layoutConfig.rowHeights || [210, 105, 90, 90];
     function renderFirstCell(parent, x, y, w, h) {
         renderCell(parent, x, y, w, h, 'lightblue');
         parent.append('line')

--- a/js/main.js
+++ b/js/main.js
@@ -52,11 +52,12 @@ function updateRenderDebugPanel(errors) {
 function renderCittaSection(viewModel, context) {
     resetCittaState();
     const model = rebuildCittaModel();
-    const subPadding = 6;
-    const ctt = renderCittaTable(cittaSvg, model, cittaState);
+    const tab1Layout = viewModel.layout.tab1;
+    const subPadding = tab1Layout.sectionSpacing.subPadding;
+    const ctt = renderCittaTable(cittaSvg, model, cittaState, tab1Layout.cittaTable);
     let cntt = null;
     let ntt = null;
-    const sidePanelLayout = viewModel.layout.cittaSidePanel;
+    const sidePanelLayout = tab1Layout.cittaSidePanel;
     const rx = ctt.endX + subPadding;
     const fet = renderFeelingTable(rx, 0);
     const ct = renderCauseTable(fet.endX + subPadding, 0);
@@ -87,8 +88,52 @@ function renderCittaSection(viewModel, context) {
     );
     setupHighlightsBehavior(cntt, ntt, cittaState);
 
-    context.endX = ctt.endX;
-    context.endY = Math.max(ntt ? ntt.endY : 0, cntt ? cntt.endY : 0);
+    const keyRegions = {
+        cittaTable: ctt,
+        feelingTable: fet,
+        causeTable: ct,
+        timeTable: tt,
+        mentalObjectTable: mot,
+        realmTable: rt,
+        gateTable: gt,
+        basisTable: bt,
+        functionTable: ft,
+        notesTable: ntt,
+        counterTable: cntt,
+    };
+    validateLayoutBounds('#citta', keyRegions);
+
+    const regionValues = Object.values(keyRegions).filter(Boolean);
+    context.endX = Math.max(...regionValues.map((r) => r.endX));
+    context.endY = Math.max(...regionValues.map((r) => r.endY));
+}
+
+function validateLayoutBounds(containerSelector, keyRegions) {
+    const container = d3.select(containerSelector);
+    if (container.empty()) {
+        return;
+    }
+    const containerNode = container.node();
+    const containerWidth = containerNode.clientWidth || Number(container.style('width').replace('px', '')) || 0;
+    const containerHeight = containerNode.clientHeight || Number(container.style('height').replace('px', '')) || 0;
+    Object.entries(keyRegions).forEach(([name, region]) => {
+        if (!region) {
+            return;
+        }
+        const widthOverflow = region.endX > containerWidth;
+        const heightOverflow = region.endY > containerHeight;
+        if (!widthOverflow && !heightOverflow) {
+            return;
+        }
+
+        const suggestedWidth = Math.ceil(Math.max(region.endX, containerWidth));
+        const suggestedHeight = Math.ceil(Math.max(region.endY, containerHeight));
+        console.warn(
+            `[layout-check] ${name} 超出 ${containerSelector} 边界：endX=${region.endX}, endY=${region.endY}, ` +
+            `containerWidth=${containerWidth}, containerHeight=${containerHeight}. 建议将 ${containerSelector} ` +
+            `至少调整为 width=${suggestedWidth}px, height=${suggestedHeight}px。`
+        );
+    });
 }
 
 function renderFlowSection(context) {

--- a/js/render-layout.js
+++ b/js/render-layout.js
@@ -13,7 +13,27 @@ const CITTA_SIDE_PANEL_LAYOUTS = {
     },
 };
 
+const TAB1_LAYOUT = {
+    cittaTable: {
+        rowHeaderWidth: 120,
+        columnWidths: [120, 120, 120, 220, 120, 120],
+        columnHeaderHeight: 105,
+        rowHeights: [210, 105, 90, 90],
+    },
+    sectionSpacing: {
+        subPadding: 6,
+    },
+};
+
 function getCittaSidePanelLayout(lang) {
     const normalizedLang = typeof lang === 'string' ? (langCfg[lang] || langCfg.cn) : (lang || langCfg.cn);
     return normalizedLang.fixed ? CITTA_SIDE_PANEL_LAYOUTS.cn : CITTA_SIDE_PANEL_LAYOUTS.en;
+}
+
+function getTab1Layout(lang) {
+    return {
+        cittaTable: { ...TAB1_LAYOUT.cittaTable },
+        sectionSpacing: { ...TAB1_LAYOUT.sectionSpacing },
+        cittaSidePanel: getCittaSidePanelLayout(lang),
+    };
 }

--- a/js/view-model.js
+++ b/js/view-model.js
@@ -6,7 +6,7 @@ function buildPageViewModel(pageState) {
             raw: { data, cittas, cetasika },
         },
         layout: {
-            cittaSidePanel: getCittaSidePanelLayout(lang),
+            tab1: getTab1Layout(lang),
             rupaNotesOffset: lang.wide ? 100 : 240,
         },
     };


### PR DESCRIPTION
### Motivation
- 将 Tab1（citta）相关的尺寸常量集中在一个单一配置对象中以减少重复硬编码并提高可维护性。 
- 在每次布局计算后做边界校验，及时发现关键渲染区域超出容器的问题并提供调整建议以避免显示/布局异常。 

### Description
- 在 `js/render-layout.js` 新增 `TAB1_LAYOUT` 并提供 `getTab1Layout(lang)`，集中定义 `columnWidths`、`rowHeights`、`rowHeaderWidth`、`columnHeaderHeight` 和 `subPadding` 等参数。 
- 在 `js/view-model.js` 将 view model 的布局字段改为 `layout.tab1`，使渲染逻辑从统一配置读取参数。 
- 在 `js/citta.js` 中扩展 `renderCittaTable(parent, model, state, layoutConfig)` 签名以接受传入的布局配置并在缺省时使用原有默认值。 
- 在 `js/main.js` 的 Tab1 渲染路径读取 `viewModel.layout.tab1` 并新增 `validateLayoutBounds('#citta', keyRegions)`，在布局后检查各关键区域的 `endX/endY` 是否超出 `#citta` 容器，并用 `console.warn` 输出包含超界信息与建议宽/高的告警。 

### Testing
- 已运行 `git status --short` 和 `git diff -- js/render-layout.js js/view-model.js js/citta.js js/main.js` 以验证变更差异，命令成功且输出如预期。 
- 已执行 `git add ... && git commit -m "refactor: centralize tab1 layout config and add bounds checks"` 并成功提交变更。 
- 未有项目级自动化单元测试在本次变更中运行（仓库中未触发额外测试），仅执行了文件/提交级的自动化检查且均成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe41de63e48327bcf0d516c056191b)