### PR TITLE
Fix rendering guards for missing citta/cetasika rows (fixes 89心 header and 心所 misalignment)

### DIFF
--- a/js/citta.js
+++ b/js/citta.js
@@ -244,6 +244,9 @@ function renderCetasikaTableByLayout(layoutConfig, y, model, state = cittaState)
             y0 += headerRowHeight;
             for (; breakPoint < subGroup.children.length; breakPoint++) {
                 const child = subGroup.children[breakPoint];
+                if (!child || !child.name) {
+                    continue;
+                }
                 state.allCetasika.push(child);
                 state.registerCetasika(child.name, child.id);
                 state.registerId(child.id, child);

--- a/js/common-svg.js
+++ b/js/common-svg.js
@@ -315,9 +315,13 @@ function renderVerticalTable(parent, x, y, w, h, title, items, padding, itemInde
     renderTextBox(tableGroup, padding, padding, w - padding * 2, headerHeight, headerColor ? headerColor : 'lightgrey', title, {size: headerFontSize, padding: 2, align: 'left'});
     const boxes = [];
     // Loop through the data items and draw each row
-    items.forEach((item, index) => {
+    (items || []).forEach((item, index) => {
+        if (!item) {
+            return;
+        }
         const yPosition = padding + headerHeight + index * rowHeight;
-        const textbox = renderTextBox(tableGroup, padding, yPosition, w - padding * 2, rowHeight, 'white', item.name, {
+        const label = typeof item === 'string' ? item : (item.name || item.displayName || '');
+        const textbox = renderTextBox(tableGroup, padding, yPosition, w - padding * 2, rowHeight, 'white', label, {
             size: '10px',
             padding: 2,
             align: 'left'
@@ -327,7 +331,9 @@ function renderVerticalTable(parent, x, y, w, h, title, items, padding, itemInde
             textbox.Y += y;
             textbox.endX += x;
             textbox.endY += y;
-            itemIndex[item.id] = textbox;
+            if (item.id !== undefined) {
+                itemIndex[item.id] = textbox;
+            }
         }
         boxes.push(textbox);
     });


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and interrupted layout when a vertical table row or a cetasika subgroup child is null or missing a `name`, which caused the 89 心 header to stop rendering and produced misalignment in the lower 心所 section.

### Description
- In `js/common-svg.js` updated `renderVerticalTable` to iterate `(items || [])`, skip falsy rows, accept plain-string rows for labels, and only register `itemIndex[item.id]` when `item.id` is defined.
- In `js/citta.js` added a guard `if (!child || !child.name) { continue; }` when iterating `subGroup.children` to avoid processing invalid cetasika entries.
- Files modified: `js/common-svg.js` and `js/citta.js` with a short commit applying these defensive checks.

### Testing
- Ran `git status --short && git diff -- js/common-svg.js js/citta.js | sed -n '1,200p'` to verify the diff touches only the intended rendering paths and it succeeded.
- Performed `git add js/citta.js js/common-svg.js && git commit -m "Fix citta/cetasika rendering guards for missing entries"` and the commit succeeded.
- Inspected modified file regions with `nl` to confirm the guard logic lines were inserted as intended and the inspection commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe47bd18848327bbaf595f4336561f)