### PR TITLE
Fix cause-condition citta alias rendering fallback

### DIFF
--- a/js/cause-condition.js
+++ b/js/cause-condition.js
@@ -11,6 +11,16 @@ function renderCauseCondition(parent) {
         '异业组': {}
     };
     const conditions = getConditions();
+    function getCittaAlias(cittaId) {
+        if (idIndex[cittaId] && idIndex[cittaId].name) {
+            return idIndex[cittaId].name;
+        }
+        const citta = Builder.getVariable(cittaId);
+        if (citta && citta.name) {
+            return citta.name;
+        }
+        return `心${cittaId}`;
+    }
     function renderConditions(parent, x, y, nama=true) {
         const groups = {};
         conditions.children.forEach((condition, index) => {
@@ -295,7 +305,7 @@ function renderCauseCondition(parent) {
     Builder.getVariable('欲界速行心').forEach((citta, index) => {
         impulseCittas1st.push({
             id: id++,
-            alias: idIndex[citta].name,
+            alias: getCittaAlias(citta),
             citta: citta
         });
     });
@@ -304,7 +314,7 @@ function renderCauseCondition(parent) {
     Builder.getVariable('欲界速行心').forEach((citta, index) => {
         impulseCittas2nd.push({
             id: id++,
-            alias: idIndex[citta].name,
+            alias: getCittaAlias(citta),
             citta: citta,
         });
     });
@@ -313,7 +323,7 @@ function renderCauseCondition(parent) {
     Builder.getVariable('彼所缘心').forEach((citta, index) => {
         recallCittas1st.push({
             id: id++,
-            alias: idIndex[citta].name,
+            alias: getCittaAlias(citta),
             citta: citta,
         });
     });
@@ -322,7 +332,7 @@ function renderCauseCondition(parent) {
     Builder.getVariable('彼所缘心').forEach((citta, index) => {
         recallCittas2nd.push({
             id: id++,
-            alias: idIndex[citta].name,
+            alias: getCittaAlias(citta),
             citta: citta,
         });
     });
@@ -695,7 +705,7 @@ function renderCauseCondition(parent) {
         Builder.getVariable(variableName).forEach((citta, index) => {
             instances.push({
                 id: id++,
-                alias: idIndex[citta].name,
+                alias: getCittaAlias(citta),
                 citta: citta,
             });
         });


### PR DESCRIPTION
### Motivation
- Rendering of cause/condition flows could throw `TypeError: Cannot read properties of undefined (reading 'name')` when some `citta` ids were not present in `idIndex`, which interrupted subsequent layout and caused header/positioning issues.
- The change aims to provide a safe alias lookup so rendering continues even when `idIndex` lacks entries for some `citta` ids.

### Description
- Added a helper `getCittaAlias(cittaId)` in `js/cause-condition.js` that returns `idIndex[cittaId].name` if present, falls back to `Builder.getVariable(cittaId).name`, and finally returns a `心{id}` placeholder.
- Replaced direct `idIndex[citta].name` accesses in the sense-flow instance builders (`欲界速行心` / `彼所缘心`) with `getCittaAlias` to avoid undefined `.name` reads.
- Replaced direct `idIndex[citta].name` usage inside the mind-flow `addInstances` builder with `getCittaAlias` so all instance aliases are resolved safely.

### Testing
- Ran `rg -n "idIndex\[citta\]\.name" js/cause-condition.js` to confirm no remaining direct accesses, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4b8bf0a08327b3d7f85d1528a72f)